### PR TITLE
(to) github.com/teamhephy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ FROM quay.io/deis/go-dev:v0.21.0
 ADD https://codecov.io/bash /usr/local/bin/codecov
 RUN chmod +x /usr/local/bin/codecov
 
-COPY glide.yaml /go/src/github.com/deis/controller-sdk-go/
-COPY glide.lock /go/src/github.com/deis/controller-sdk-go/
+COPY glide.yaml /go/src/github.com/teamhephy/controller-sdk-go/
+COPY glide.lock /go/src/github.com/teamhephy/controller-sdk-go/
 
-WORKDIR /go/src/github.com/deis/controller-sdk-go
+WORKDIR /go/src/github.com/teamhephy/controller-sdk-go
 
 RUN glide install --strip-vendor
 
 COPY ./_scripts /usr/local/bin
 
-COPY . /go/src/github.com/deis/controller-sdk-go
+COPY . /go/src/github.com/teamhephy/controller-sdk-go

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node('linux') {
 	}
 }
 
-def test_image = "quay.io/deisci/controller-sdk-go-dev:${git_commit.take(7)}"
+def test_image = "quay.io/kingdonb/controller-sdk-go-dev:${git_commit.take(7)}"
 
 node('linux') {
 		stage 'Build and push test container'
@@ -95,7 +95,7 @@ node('linux') {
 stage 'Build and Upload CLI built with SDK'
 
 def gcs_bucket = "gs://workflow-cli-pr"
-def wcli_image = 'quay.io/deisci/workflow-cli-dev:latest'
+def wcli_image = 'quay.io/kingdonb/workflow-cli-dev:latest'
 
 
 def upload_artifacts = { String dist_dir ->
@@ -146,7 +146,7 @@ node('linux') {
 	replacement += "  version: ${git_commit}"
 
 	def build_script = "sh -c 'perl -i -0pe \"s/${pattern}/${replacement}/\" glide.yaml "
-	build_script += "&& rm -rf glide.lock vendor/github.com/deis/controller-sdk-go "
+	build_script += "&& rm -rf glide.lock vendor/github.com/teamhephy/controller-sdk-go "
 	build_script += "&& glide install "
 	build_script += "&& make build-revision'"
 	sh "docker pull ${wcli_image}"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # the filepath to this repository, relative to $GOPATH/src
-repo_path = github.com/deis/controller-sdk-go
+repo_path = github.com/teamhephy/controller-sdk-go
 
 REVISION ?= $(shell git rev-parse --short HEAD)
 REGISTRY ?= quay.io/

--- a/api/certs.go
+++ b/api/certs.go
@@ -1,6 +1,6 @@
 package api
 
-import "github.com/deis/controller-sdk-go/pkg/time"
+import "github.com/teamhephy/controller-sdk-go/pkg/time"
 
 // Cert is the definition of the cert object.
 // Some fields are omtempty because they are only

--- a/api/ps.go
+++ b/api/ps.go
@@ -1,6 +1,6 @@
 package api
 
-import "github.com/deis/controller-sdk-go/pkg/time"
+import "github.com/teamhephy/controller-sdk-go/pkg/time"
 
 // ProcessType represents the key/value mappings of a process type to a process inside
 // a Heroku Procfile.

--- a/api/ps_test.go
+++ b/api/ps_test.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/deis/controller-sdk-go/pkg/time"
+	"github.com/teamhephy/controller-sdk-go/pkg/time"
 )
 
 func TestPodsListSorted(t *testing.T) {

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -8,8 +8,8 @@ import (
 	"io/ioutil"
 	"strconv"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // ErrNoLogs is returned when logs are missing from an app.

--- a/apps/apps_test.go
+++ b/apps/apps_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const appFixture string = `

--- a/appsettings/appsettings.go
+++ b/appsettings/appsettings.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists an app's settings.

--- a/appsettings/appsettings_test.go
+++ b/appsettings/appsettings_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const appSettingsFixture string = `

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,8 +4,8 @@ package auth
 import (
 	"encoding/json"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // Register a new user with the controller.

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
+	deis "github.com/teamhephy/controller-sdk-go"
 )
 
 const registerExpected string = `{"username":"test","password":"opensesame","email":"test@example.com"}`

--- a/builds/builds.go
+++ b/builds/builds.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists an app's builds.

--- a/builds/builds_test.go
+++ b/builds/builds_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const buildsFixture string = `

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists certificates added to deis.

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/pkg/time"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/pkg/time"
 )
 
 const certsFixture string = `

--- a/config/config.go
+++ b/config/config.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists an app's config.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const configFixture string = `

--- a/domains/domains.go
+++ b/domains/domains.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List domains registered with an app.

--- a/domains/domains_test.go
+++ b/domains/domains_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const domainsFixture string = `

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,3 @@
-package: github.com/deis/controller-sdk-go
+package: github.com/teamhephy/controller-sdk-go
 import:
 - package: github.com/goware/urlx

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // UserFromKey retrives a user from their SSH key fingerprint.

--- a/hooks/hooks_test.go
+++ b/hooks/hooks_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const keyFixture string = `

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists a user's ssh keys.

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const keysFixture string = `

--- a/perms/perms.go
+++ b/perms/perms.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List users that can access an app.

--- a/perms/perms_test.go
+++ b/perms/perms_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
+	deis "github.com/teamhephy/controller-sdk-go"
 )
 
 const adminFixture string = `

--- a/ps/ps.go
+++ b/ps/ps.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sort"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists an app's processes.

--- a/ps/ps_test.go
+++ b/ps/ps_test.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
-	"github.com/deis/controller-sdk-go/pkg/time"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
+	"github.com/teamhephy/controller-sdk-go/pkg/time"
 )
 
 const processesFixture string = `

--- a/releases/releases.go
+++ b/releases/releases.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists an app's releases.

--- a/releases/releases_test.go
+++ b/releases/releases_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const releasesFixture string = `

--- a/tls/tls.go
+++ b/tls/tls.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // Info displays an app's tls config.

--- a/tls/tls_test.go
+++ b/tls/tls_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const (

--- a/users/users.go
+++ b/users/users.go
@@ -4,8 +4,8 @@ package users
 import (
 	"encoding/json"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List lists users registered with the controller.

--- a/users/users_test.go
+++ b/users/users_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const usersFixture string = `

--- a/whitelist/whitelist.go
+++ b/whitelist/whitelist.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 // List IP's whitelisted for an app.

--- a/whitelist/whitelist_test.go
+++ b/whitelist/whitelist_test.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"testing"
 
-	deis "github.com/deis/controller-sdk-go"
-	"github.com/deis/controller-sdk-go/api"
+	deis "github.com/teamhephy/controller-sdk-go"
+	"github.com/teamhephy/controller-sdk-go/api"
 )
 
 const whitelistFixture string = `


### PR DESCRIPTION
and quay.io/kingdonb (the temporary home of the build-time dependencies

This one is to merge if you please @Cryptophobia 

We can switch everything from quay.io/kingdonb to quay.io/ [the team account] before the first release, but ... this way for now

We are going to have to make these `github.com/deis` -> `github.com/teamhephy` go-dep changes all over the place to make the build processes work though, I'm afraid.

I'm not sure how many more repos have this issue, but I'm not in a hurry to update them all at once.  Let's make these kind of updates on each repo individually, only as we're ready to do smoke testing of each component.